### PR TITLE
[#1007] Missing seed screen lacks any back button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ directly impact users rather than highlighting other crucial architectural updat
 ### Fixed
 - Restore mode in the UI was missing when Zashi was deleted from an iPhone and reinstalled again.
 - Syncing bar in the restore mode bottom padding.
+- Missing exit button at backup phrase screen when no words are stored in the keychain.
 
 ### Added
 - Pending values (changes) at the Balances tab.

--- a/modules/Sources/Features/RecoveryPhraseDisplay/RecoveryPhraseDisplayView.swift
+++ b/modules/Sources/Features/RecoveryPhraseDisplay/RecoveryPhraseDisplayView.swift
@@ -74,17 +74,18 @@ public struct RecoveryPhraseDisplayView: View {
                                 .font(.custom(FontFamily.Inter.regular.name, size: 14))
                                 .padding(.bottom, 15)
                         }
-                        
-                        Button(L10n.RecoveryPhraseDisplay.Button.wroteItDown.uppercased()) {
-                            viewStore.send(.finishedPressed)
-                        }
-                        .zcashStyle()
-                        .padding(.bottom, 50)
                     } else {
                         Text(L10n.RecoveryPhraseDisplay.noWords)
                             .font(.custom(FontFamily.Inter.regular.name, size: 14))
                             .multilineTextAlignment(.center)
+                            .padding(.bottom, 35)
                     }
+
+                    Button(L10n.RecoveryPhraseDisplay.Button.wroteItDown.uppercased()) {
+                        viewStore.send(.finishedPressed)
+                    }
+                    .zcashStyle()
+                    .padding(.bottom, 50)
                 }
                 .padding(.horizontal, 60)
                 .onAppear { viewStore.send(.onAppear) }


### PR DESCRIPTION
Closes #1007 

- Exit button from the screen moved one layer up to show even when no words are stored
- Changelog updated

<img width="424" alt="Screenshot 2024-02-06 at 8 54 01" src="https://github.com/Electric-Coin-Company/zashi-ios/assets/7198042/346b189e-091d-4f8c-84d4-9f4b06567698">

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [x] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [ ] Does the code abide by the [Coding Guidelines](../blob/main/docs/CODING_GUIDELINES.md)?
- [ ] Automated tests: Did you add appropriate automated tests for any code changes?
- [x] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [x] Run the app: Did you run the app and try the changes? 
- [x] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [x] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/main/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage before and after your changes and when possible, leave it in a better place. [Learn More...](../blob/main/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/main/README.md), [LICENSE.md](../blob/main/LICENSE.md), and [Architecture.md](../blob/main/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.