### PR TITLE
[#1056] Redactable AccountBalance

### DIFF
--- a/modules/Sources/Features/Root/RootInitialization.swift
+++ b/modules/Sources/Features/Root/RootInitialization.swift
@@ -58,7 +58,7 @@ extension RootReducer {
                 }
                 
             case .synchronizerStateChanged(let latestState):
-                let snapshot = SyncStatusSnapshot.snapshotFor(state: latestState.syncStatus)
+                let snapshot = SyncStatusSnapshot.snapshotFor(state: latestState.data.syncStatus)
 
                 guard state.bgTask != nil else {
                     return .send(.initialization(.checkRestoreWalletFlag(snapshot.syncStatus)))
@@ -125,6 +125,7 @@ extension RootReducer {
                 return .publisher {
                     sdkSynchronizer.stateStream()
                         .throttle(for: .seconds(0.2), scheduler: mainQueue, latest: true)
+                        .map { $0.redacted }
                         .map(RootReducer.Action.synchronizerStateChanged)
                 }
                 .cancellable(id: CancelStateId.timer, cancelInFlight: true)

--- a/modules/Sources/Features/Root/RootStore.swift
+++ b/modules/Sources/Features/Root/RootStore.swift
@@ -19,6 +19,7 @@ import ReadTransactionsStorage
 import RecoveryPhraseDisplay
 import BackgroundTasks
 import RestoreWalletStorage
+import Utils
 
 public typealias RootStore = Store<RootReducer.State, RootReducer.Action>
 public typealias RootViewStore = ViewStore<RootReducer.State, RootReducer.Action>
@@ -103,7 +104,7 @@ public struct RootReducer: Reducer {
         case splashFinished
         case splashRemovalRequested
         case sandbox(SandboxReducer.Action)
-        case synchronizerStateChanged(SynchronizerState)
+        case synchronizerStateChanged(RedactableSynchronizerState)
         case updateStateAfterConfigUpdate(WalletConfig)
         case walletConfigLoaded(WalletConfig)
         case welcome(WelcomeReducer.Action)

--- a/modules/Sources/Utils/SensitiveData.swift
+++ b/modules/Sources/Utils/SensitiveData.swift
@@ -14,11 +14,11 @@ import ZcashLightClientKit
 /// destriptions and dumps never print outs the exact value but `--redacted--` instead.
 /// `Redactable` protocol is just a helper so we can let developers to see the sensitive data when
 /// developing and debugging but production or release builds (even testflight) are set to redacted by default.
-#if DEBUG
-public protocol Redactable { }
-#else
+//#if DEBUG
+//public protocol Redactable { }
+//#else
 public protocol Redactable: Undescribable { }
-#endif
+//#endif
 
 // MARK: - Redactable Seed Phrase
 
@@ -82,7 +82,7 @@ extension BlockHeight {
     public var redacted: RedactableBlockHeight { RedactableBlockHeight(self) }
 }
 
-// MARK: - Redactable AccountBalance & SynchronizerState
+// MARK: - Redactable AccountBalance
 
 /// Redactable holder for a block height.
 public struct RedactableAccountBalance: Equatable, Redactable {
@@ -94,6 +94,36 @@ public struct RedactableAccountBalance: Equatable, Redactable {
 /// Utility that converts a block height to a redacted counterpart.
 extension AccountBalance {
     public var redacted: RedactableAccountBalance? { RedactableAccountBalance(self) }
+}
+
+// MARK: - Redactable SynchronizerState
+
+/// Redactable holder for a block height.
+public struct RedactableSynchronizerState: Equatable, Redactable {
+    public struct SynchronizerStateWrapper: Equatable {
+        public var syncSessionID: UUID
+        public var accountBalance: RedactableAccountBalance?
+        public var syncStatus: SyncStatus
+        public var latestBlockHeight: BlockHeight
+    }
+
+    public let data: SynchronizerStateWrapper
+
+    public init(_ data: SynchronizerState) {
+        self.data = SynchronizerStateWrapper(
+            syncSessionID: data.syncSessionID,
+            accountBalance: data.accountBalance?.redacted,
+            syncStatus: data.syncStatus,
+            latestBlockHeight: data.latestBlockHeight
+        )
+    }
+}
+
+/// Utility that converts a block height to a redacted counterpart.
+extension SynchronizerState {
+    public var redacted: RedactableSynchronizerState {
+        RedactableSynchronizerState(self)
+    }
 }
 
 // MARK: - Redactable Int64

--- a/secantTests/BalanceBreakdownTests/BalanceBreakdownTests.swift
+++ b/secantTests/BalanceBreakdownTests/BalanceBreakdownTests.swift
@@ -31,7 +31,7 @@ class BalanceBreakdownTests: XCTestCase {
         await store.send(.onAppear)
         
         // expected side effects as a result of .onAppear registration
-        await store.receive(.synchronizerStateChanged(.zero))
+        await store.receive(.synchronizerStateChanged(SynchronizerState.zero.redacted))
 
         // long-living (cancelable) effects need to be properly canceled.
         // the .onDisappear action cancels the observer of the synchronizer status change.

--- a/secantTests/HomeTests/HomeTests.swift
+++ b/secantTests/HomeTests/HomeTests.swift
@@ -61,7 +61,7 @@ class HomeTests: XCTestCase {
 
         // expected side effects as a result of .onAppear registration
         await store.receive(.updateDestination(nil))
-        await store.receive(.synchronizerStateChanged(.zero)) { state in
+        await store.receive(.synchronizerStateChanged(SynchronizerState.zero.redacted)) { state in
             state.synchronizerStatusSnapshot = snapshot
         }
 
@@ -113,7 +113,7 @@ class HomeTests: XCTestCase {
             HomeReducer()
         }
 
-        await store.send(.synchronizerStateChanged(state)) { state in
+        await store.send(.synchronizerStateChanged(state.redacted)) { state in
             state.synchronizerStatusSnapshot = errorSnapshot
             state.migratingDatabase = false
         }

--- a/secantTests/ReviewRequestTests/ReviewRequestTests.swift
+++ b/secantTests/ReviewRequestTests/ReviewRequestTests.swift
@@ -46,7 +46,7 @@ final class ReviewRequestTests: XCTestCase {
         syncState.syncStatus = .upToDate
         let snapshot = SyncStatusSnapshot.snapshotFor(state: syncState.syncStatus)
         
-        await store.send(.synchronizerStateChanged(syncState)) { state in
+        await store.send(.synchronizerStateChanged(syncState.redacted)) { state in
             state.synchronizerStatusSnapshot = snapshot
             state.migratingDatabase = false
         }

--- a/secantTests/RootTests/RestoreWalletTests.swift
+++ b/secantTests/RootTests/RestoreWalletTests.swift
@@ -68,7 +68,7 @@ final class RestoreWalletTests: XCTestCase {
         var syncState: SynchronizerState = .zero
         syncState.syncStatus = .upToDate
 
-        await store.send(.synchronizerStateChanged(syncState))
+        await store.send(.synchronizerStateChanged(syncState.redacted))
         
         await store.receive(.initialization(.checkRestoreWalletFlag(syncState.syncStatus))) { state in
             state.isRestoringWallet = false

--- a/secantTests/SyncProgressTests/SyncProgressTests.swift
+++ b/secantTests/SyncProgressTests/SyncProgressTests.swift
@@ -70,7 +70,7 @@ final class SyncProgressTests: XCTestCase {
         syncState.syncStatus = .upToDate
         let snapshot = SyncStatusSnapshot.snapshotFor(state: syncState.syncStatus)
         
-        await store.send(.synchronizerStateChanged(syncState)) { state in
+        await store.send(.synchronizerStateChanged(syncState.redacted)) { state in
             state.synchronizerStatusSnapshot = snapshot
             state.syncStatusMessage = "Synced"
             state.lastKnownSyncPercentage = 1.0
@@ -91,7 +91,7 @@ final class SyncProgressTests: XCTestCase {
         syncState.syncStatus = .syncing(0.545)
         let snapshot = SyncStatusSnapshot.snapshotFor(state: syncState.syncStatus)
         
-        await store.send(.synchronizerStateChanged(syncState)) { state in
+        await store.send(.synchronizerStateChanged(syncState.redacted)) { state in
             state.synchronizerStatusSnapshot = snapshot
             state.syncStatusMessage = "Syncing"
             state.lastKnownSyncPercentage = 0.545


### PR DESCRIPTION
Closes #1056 

- AccountBalance has been wrapped into RedactableAccountBalance
- SynchronizerState has been wrapped into RedactableSynchronizerState
- Code updated to use these new redactable structs instead of direct use of unredacted ones
- tests fixed

<img width="344" alt="Screenshot 2024-02-15 at 12 26 44" src="https://github.com/Electric-Coin-Company/zashi-ios/assets/7198042/d6a686a2-2cee-4dc4-a0b6-f457a5c62415">

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [x] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [ ] Does the code abide by the [Coding Guidelines](../blob/main/docs/CODING_GUIDELINES.md)?
- [ ] Automated tests: Did you add appropriate automated tests for any code changes?
- [x] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [x] Run the app: Did you run the app and try the changes? 
- [x] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [x] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/main/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage before and after your changes and when possible, leave it in a better place. [Learn More...](../blob/main/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/main/README.md), [LICENSE.md](../blob/main/LICENSE.md), and [Architecture.md](../blob/main/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.