### PR TITLE
[#1067] Disable logging for production

### DIFF
--- a/modules/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
+++ b/modules/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
@@ -23,6 +23,12 @@ extension SDKSynchronizerClient: DependencyKey {
         
         let network = zcashSDKEnvironment.network
         
+        #if DEBUG
+        let loggingPolicy = Initializer.LoggingPolicy.default(.debug)
+        #else
+        let loggingPolicy = Initializer.LoggingPolicy.noLogging
+        #endif
+        
         let initializer = Initializer(
             cacheDbURL: databaseFiles.cacheDbURLFor(network),
             fsBlockDbRoot: databaseFiles.fsBlockDbRootFor(network),
@@ -33,7 +39,7 @@ extension SDKSynchronizerClient: DependencyKey {
             spendParamsURL: databaseFiles.spendParamsURLFor(network),
             outputParamsURL: databaseFiles.outputParamsURLFor(network),
             saplingParamsSourceURL: SaplingParamsSourceURL.default,
-            loggingPolicy: .default(.debug)
+            loggingPolicy: loggingPolicy
         )
         
         let synchronizer = SDKSynchronizer(initializer: initializer)

--- a/modules/Sources/Features/PrivateDataConsent/PrivateDataConsentView.swift
+++ b/modules/Sources/Features/PrivateDataConsent/PrivateDataConsentView.swift
@@ -66,6 +66,7 @@ public struct PrivateDataConsentView: View {
                     .padding(.horizontal, 8)
                     .padding(.bottom, 25)
 
+                    #if DEBUG
                     Button {
                         viewStore.send(.exportLogsRequested)
                     } label: {
@@ -80,6 +81,7 @@ public struct PrivateDataConsentView: View {
                     .disabled(!viewStore.isExportPossible)
                     .padding(.horizontal, 8)
                     .padding(.bottom, 50)
+                    #endif
                 }
                 .padding(.horizontal, 60)
             }

--- a/modules/Sources/Utils/Logging/TCALogging.swift
+++ b/modules/Sources/Utils/Logging/TCALogging.swift
@@ -14,12 +14,14 @@ extension OSLogger {
 
     public func tcaDebug(_ message: String) {
         guard let oslog else { return }
-        
+
+        #if DEBUG
         os_log(
             "%{public}@",
             log: oslog,
             type: .default,
             message
         )
+        #endif
     }
 }

--- a/secant/AppDelegate.swift
+++ b/secant/AppDelegate.swift
@@ -35,9 +35,8 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
 #if DEBUG
         // Short-circuit if running unit tests to avoid side-effects from the app running.
         guard !_XCTIsTesting else { return true }
-#endif
-        
         walletLogger = OSLogger(logLevel: .debug, category: LoggerConstants.walletLogs)
+#endif
         
         handleBackgroundTask()
 


### PR DESCRIPTION
Closes #1067 

- There are 3 different and independent loggers that have been disabled for production (release configuration builds)
- The TCA logger doesn't call os_log()
- The SDK is instantiated with .noLogging policy
- The Wallet logger is never set so it's nil
- With no logs the export logs button in Export Private Data screen no longer makes sense so I removed it from the UI

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [x] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [ ] Does the code abide by the [Coding Guidelines](../blob/main/docs/CODING_GUIDELINES.md)?
- [ ] Automated tests: Did you add appropriate automated tests for any code changes?
- [x] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [x] Run the app: Did you run the app and try the changes? 
- [ ] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [x] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/main/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage before and after your changes and when possible, leave it in a better place. [Learn More...](../blob/main/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/main/README.md), [LICENSE.md](../blob/main/LICENSE.md), and [Architecture.md](../blob/main/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.