### PR TITLE
[#1076] Keychain claims no data exist and data exist at the same time

### DIFF
--- a/secantTests/SendTests/SendTests.swift
+++ b/secantTests/SendTests/SendTests.swift
@@ -21,11 +21,12 @@ import UIComponents
 class SendTests: XCTestCase {
     var storage = WalletStorage(secItem: .live)
     let usNumberFormatter = NumberFormatter()
+    let account = "test_account"
 
     override func setUp() {
         super.setUp()
         storage.zcashStoredWalletPrefix = "test_send_"
-        storage.deleteData(forKey: WalletStorage.Constants.zcashStoredWallet)
+        storage.deleteData(forKey: WalletStorage.Constants.zcashStoredWallet, account: account)
 
         usNumberFormatter.maximumFractionDigits = 8
         usNumberFormatter.maximumIntegerDigits = 8

--- a/secantTests/UtilTests/SecItemClientTests.swift
+++ b/secantTests/UtilTests/SecItemClientTests.swift
@@ -24,6 +24,8 @@ extension WalletStorage.KeychainError {
 }
 
 class SecItemClientTests: XCTestCase {
+    let account = "test_account"
+    
     func test_secItemAdd_KeychainErrorDuplicate() throws {
         let secItemDuplicate = SecItemClient(
             copyMatching: { _, _ in errSecSuccess },
@@ -35,7 +37,7 @@ class SecItemClientTests: XCTestCase {
         let walletStorage = WalletStorage(secItem: secItemDuplicate)
         
         do {
-            try walletStorage.setData(Data(), forKey: "")
+            try walletStorage.setData(Data(), forKey: "", account: account)
 
             XCTFail("SecItemClient: test_secItemAdd_KeychainErrorDuplicate expected to fail but passed.")
         } catch {
@@ -64,7 +66,7 @@ class SecItemClientTests: XCTestCase {
         let walletStorage = WalletStorage(secItem: secItemDuplicate)
         
         do {
-            try walletStorage.setData(Data(), forKey: "")
+            try walletStorage.setData(Data(), forKey: "", account: account)
 
             XCTFail("SecItemClient: test_secItemAdd_KeychainErrorUnknown expected to fail but passed.")
         } catch {
@@ -93,7 +95,7 @@ class SecItemClientTests: XCTestCase {
         let walletStorage = WalletStorage(secItem: secItemDuplicate)
         
         do {
-            try walletStorage.updateData(Data(), forKey: "")
+            try walletStorage.updateData(Data(), forKey: "", account: account)
 
             XCTFail("SecItemClient: test_secItemUpdate_KeychainErrorNoDataFound expected to fail but passed.")
         } catch {
@@ -122,7 +124,7 @@ class SecItemClientTests: XCTestCase {
         let walletStorage = WalletStorage(secItem: secItemDuplicate)
         
         do {
-            try walletStorage.updateData(Data(), forKey: "")
+            try walletStorage.updateData(Data(), forKey: "", account: account)
 
             XCTFail("SecItemClient: test_secItemUpdate_KeychainErrorUnknown expected to fail but passed.")
         } catch {
@@ -150,7 +152,7 @@ class SecItemClientTests: XCTestCase {
         
         let walletStorage = WalletStorage(secItem: secItemDuplicate)
         
-        let result = walletStorage.deleteData(forKey: "")
+        let result = walletStorage.deleteData(forKey: "", account: account)
         
         XCTAssertTrue(result)
     }
@@ -165,7 +167,7 @@ class SecItemClientTests: XCTestCase {
         
         let walletStorage = WalletStorage(secItem: secItemDuplicate)
         
-        let result = walletStorage.deleteData(forKey: "")
+        let result = walletStorage.deleteData(forKey: "", account: account)
         
         XCTAssertFalse(result)
     }

--- a/secantTests/UtilTests/WalletStorageTests.swift
+++ b/secantTests/UtilTests/WalletStorageTests.swift
@@ -34,6 +34,7 @@ class WalletStorageTests: XCTestCase {
     override func setUp() {
         super.setUp()
         storage.zcashStoredWalletPrefix = "test_walletStorage_"
+        storage.zcashStoredWalletAccount = "test_account"
         deleteData(forKey: WalletStorage.Constants.zcashStoredWallet)
     }
     
@@ -287,7 +288,7 @@ class WalletStorageTests: XCTestCase {
 /// The followings methods are here purposely to not rely on `WalletStorage` in order to test functionality of JUST ONE method at a time
 private extension WalletStorageTests {
     private func setData(
-        account: String = "",
+        account: String = "test_account",
         _ data: Data,
         forKey: String
     ) throws {
@@ -300,7 +301,7 @@ private extension WalletStorageTests {
     
     private func data(
         forKey: String,
-        account: String = ""
+        account: String = "test_account"
     ) -> Data? {
         let query = storage.restoreQuery(forAccount: account, andKey: forKey)
 
@@ -314,7 +315,7 @@ private extension WalletStorageTests {
     @discardableResult
     private func deleteData(
         forKey: String,
-        account: String = ""
+        account: String = "test_account"
     ) -> Bool {
         let query = storage.baseQuery(forAccount: account, andKey: forKey)
 
@@ -327,7 +328,7 @@ private extension WalletStorageTests {
     func updateData(
         _ data: Data,
         forKey: String,
-        account: String = ""
+        account: String = "test_account"
     ) throws {
         let query = storage.baseQuery(forAccount: account, andKey: forKey)
         


### PR DESCRIPTION
Closes #1076

- The Queries and Uniqueness Constraints are not defined for account which plays a role with any accessibility value of keychain. We needed to ensure the account ID is defined and unique across all AppStore apps.
- The migration of previously stored wallet is unfortunately not possible because the previous wallet can't be read - that is definition of this ticket and bug described. This forces us to stay on the accessibility value we choose for Zashi 1.0 and never change it later. We decided to stick with `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` moving forward.
- With the new changes, all keychain and sec item tests pass and Uniqueness improved - Zashi specific account is used instead of an empty string

**NOTE: This PR doesn't solve the problem with switching between flags of keychain accessibility, it only improves uniqueness by setting the account**

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [x] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [ ] Does the code abide by the [Coding Guidelines](../blob/main/docs/CODING_GUIDELINES.md)?
- [ ] Automated tests: Did you add appropriate automated tests for any code changes?
- [x] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [x] Run the app: Did you run the app and try the changes? 
- [ ] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [x] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/main/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage before and after your changes and when possible, leave it in a better place. [Learn More...](../blob/main/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/main/README.md), [LICENSE.md](../blob/main/LICENSE.md), and [Architecture.md](../blob/main/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.