### PR TITLE
Add zec.rocks to the server list

### DIFF
--- a/modules/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentInterface.swift
+++ b/modules/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentInterface.swift
@@ -29,6 +29,10 @@ extension ZcashSDKEnvironment {
         case saNW
         case euNW
         case aiNW
+        case globalZR
+        case saZR
+        case euZR
+        case apZR
         case custom
         
         public func server() -> String {
@@ -38,6 +42,10 @@ extension ZcashSDKEnvironment {
             case .saNW: return "sa.lightwalletd.com:443"
             case .euNW: return "eu.lightwalletd.com:443"
             case .aiNW: return "ai.lightwalletd.com:443"
+            case .globalZR: return "zec.rocks:443"
+            case .saZR: return "sa.zec.rocks:443"
+            case .euZR: return "eu.zec.rocks:443"
+            case .apZR: return "ap.zec.rocks:443"
             case .custom: return "custom"
             }
         }
@@ -51,7 +59,7 @@ extension ZcashSDKEnvironment {
                     secure: true,
                     streamingCallTimeoutInMillis: ZcashSDKConstants.streamingCallTimeoutInMillis
                 )
-            case .naNW, .saNW, .euNW, .aiNW:
+            case .naNW, .saNW, .euNW, .aiNW, .globalZR, .saZR, .euZR, .apZR:
                 return LightWalletEndpoint(
                     address: String(self.server().dropLast(4)),
                     port: 443,


### PR DESCRIPTION
This pull request adds Zec.rocks to Zashi as a lightwalletd server option for iOS.

Zec.rocks is new lightwalletd infrastructure [funded by a ZCG award](https://forum.zcashcommunity.com/t/rfp-zcash-lightwalletd-infrastructure-development-and-maintenance/47080). It is globally load-balanced, currently across four regions, with an emphasis on using dedicated hardware and infrastructure-as-code. We are in the process of open-sourcing the Kubernetes helm charts used to maintain this new infrastructure to make it easier for people to host their own light wallet servers.

The "zec.rocks:443" endpoint is globally load-balanced using anycast, automatically routing users to their closest region.

The screenshot below shows the modified UI page on the smallest iOS device confirming that the list fits on the screen.

<img width="511" alt="zashi zecrocks ios" src="https://github.com/Electric-Coin-Company/zashi-ios/assets/19352366/49015b4b-4580-4d08-97ee-ab79818e9679">

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [x] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [x] Does the code abide by the [Coding Guidelines](../blob/main/docs/CODING_GUIDELINES.md)?
- [ ] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [x] Run the app: Did you run the app and try the changes? 
- [x] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [x] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/main/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage before and after your changes and when possible, leave it in a better place. [Learn More...](../blob/main/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/main/README.md), [LICENSE.md](../blob/main/LICENSE.md), and [Architecture.md](../blob/main/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.