### PR TITLE
[#1223] Fallback missing server to custom field

### DIFF
--- a/modules/Package.swift
+++ b/modules/Package.swift
@@ -525,7 +525,7 @@ let package = Package(
                 "Generated",
                 "SDKSynchronizer",
                 "UIComponents",
-                "UserDefaults",
+                "UserPreferencesStorage",
                 "ZcashSDKEnvironment",
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
                 .product(name: "ZcashLightClientKit", package: "zcash-swift-wallet-sdk")
@@ -646,7 +646,8 @@ let package = Package(
             name: "UserPreferencesStorage",
             dependencies: [
                 "UserDefaults",
-                .product(name: "ComposableArchitecture", package: "swift-composable-architecture")
+                .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
+                .product(name: "ZcashLightClientKit", package: "zcash-swift-wallet-sdk")
             ],
             path: "Sources/Dependencies/UserPreferencesStorage"
         ),
@@ -706,7 +707,9 @@ let package = Package(
         .target(
             name: "ZcashSDKEnvironment",
             dependencies: [
+                "Generated",
                 "UserDefaults",
+                "UserPreferencesStorage",
                 .product(name: "ZcashLightClientKit", package: "zcash-swift-wallet-sdk"),
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture")
             ],

--- a/modules/Sources/Dependencies/UserPreferencesStorage/UserPreferencesStorageInterface.swift
+++ b/modules/Sources/Dependencies/UserPreferencesStorage/UserPreferencesStorageInterface.swift
@@ -16,23 +16,8 @@ extension DependencyValues {
 }
 
 public struct UserPreferencesStorageClient {
-    public var activeAppSessionFrom: () -> TimeInterval
-    public var setActiveAppSessionFrom: (TimeInterval) async -> Void
-
-    public var currency: () -> String
-    public var setCurrency: (String) async -> Void
-
-    public var isFiatConverted: () -> Bool
-    public var setIsFiatConverted: (Bool) async -> Void
-
-    public var isRecoveryPhraseTestCompleted: () -> Bool
-    public var setIsRecoveryPhraseTestCompleted: (Bool) async -> Void
-
-    public var isSessionAutoshielded: () -> Bool
-    public var setIsSessionAutoshielded: (Bool) async -> Void
-
-    public var isUserOptedOutOfCrashReporting: () -> Bool
-    public var setIsUserOptedOutOfCrashReporting: (Bool) async -> Void
+    public var server: () -> UserPreferencesStorage.ServerConfig?
+    public var setServer: (UserPreferencesStorage.ServerConfig) throws -> Void
 
     public var removeAll: () async -> Void
 }

--- a/modules/Sources/Dependencies/UserPreferencesStorage/UserPreferencesStorageLive.swift
+++ b/modules/Sources/Dependencies/UserPreferencesStorage/UserPreferencesStorageLive.swift
@@ -13,22 +13,8 @@ extension UserPreferencesStorageClient: DependencyKey {
         let live = UserPreferencesStorage.live
 
         return UserPreferencesStorageClient(
-            activeAppSessionFrom: { live.activeAppSessionFrom },
-            setActiveAppSessionFrom: live.setActiveAppSessionFrom(_:),
-            currency: { live.currency },
-            setCurrency: live.setCurrency(_:),
-            isFiatConverted: { live.isFiatConverted },
-            setIsFiatConverted: live.setIsFiatConverted(_:),
-            isRecoveryPhraseTestCompleted: {
-                live.isRecoveryPhraseTestCompleted
-            },
-            setIsRecoveryPhraseTestCompleted: live.setIsRecoveryPhraseTestCompleted(_:),
-            isSessionAutoshielded: { live.isSessionAutoshielded },
-            setIsSessionAutoshielded: live.setIsSessionAutoshielded(_:),
-            isUserOptedOutOfCrashReporting: {
-                live.isUserOptedOutOfCrashReporting
-            },
-            setIsUserOptedOutOfCrashReporting: live.setIsUserOptedOutOfCrashReporting(_:),
+            server: { live.server },
+            setServer: live.setServer(_:),
             removeAll: live.removeAll
         )
     }()
@@ -36,12 +22,7 @@ extension UserPreferencesStorageClient: DependencyKey {
 
 extension UserPreferencesStorage {
     public static let live = UserPreferencesStorage(
-        appSessionFrom: Date().timeIntervalSince1970,
-        convertedCurrency: "USD",
-        fiatConvertion: true,
-        recoveryPhraseTestCompleted: false,
-        sessionAutoshielded: true,
-        userOptedOutOfCrashReporting: false,
+        defaultServer: Data(),
         userDefaults: .live()
     )
 }

--- a/modules/Sources/Dependencies/UserPreferencesStorage/UserPreferencesStorageMocks.swift
+++ b/modules/Sources/Dependencies/UserPreferencesStorage/UserPreferencesStorageMocks.swift
@@ -13,22 +13,8 @@ extension UserPreferencesStorageClient: TestDependencyKey {
         let mock = UserPreferencesStorage.mock
 
         return UserPreferencesStorageClient(
-            activeAppSessionFrom: { mock.activeAppSessionFrom },
-            setActiveAppSessionFrom: mock.setActiveAppSessionFrom(_:),
-            currency: { mock.currency },
-            setCurrency: mock.setCurrency(_:),
-            isFiatConverted: { mock.isFiatConverted },
-            setIsFiatConverted: mock.setIsFiatConverted(_:),
-            isRecoveryPhraseTestCompleted: {
-                mock.isRecoveryPhraseTestCompleted
-            },
-            setIsRecoveryPhraseTestCompleted: mock.setIsRecoveryPhraseTestCompleted(_:),
-            isSessionAutoshielded: { mock.isSessionAutoshielded },
-            setIsSessionAutoshielded: mock.setIsSessionAutoshielded(_:),
-            isUserOptedOutOfCrashReporting: {
-                mock.isUserOptedOutOfCrashReporting
-            },
-            setIsUserOptedOutOfCrashReporting: mock.setIsUserOptedOutOfCrashReporting(_:),
+            server: { mock.server },
+            setServer: mock.setServer(_:),
             removeAll: mock.removeAll
         )
     }()
@@ -36,12 +22,7 @@ extension UserPreferencesStorageClient: TestDependencyKey {
 
 extension UserPreferencesStorage {
     public static let mock = UserPreferencesStorage(
-        appSessionFrom: 1651039606.0,
-        convertedCurrency: "USD",
-        fiatConvertion: true,
-        recoveryPhraseTestCompleted: false,
-        sessionAutoshielded: true,
-        userOptedOutOfCrashReporting: false,
+        defaultServer: Data(),
         userDefaults: .noOp
     )
 }

--- a/modules/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentLiveKey.swift
+++ b/modules/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentLiveKey.swift
@@ -8,45 +8,88 @@
 import ComposableArchitecture
 import ZcashLightClientKit
 
+import UserPreferencesStorage
+import UserDefaults
+
 extension ZcashSDKEnvironment {
     public static func live(network: ZcashNetwork) -> Self {
         Self(
             latestCheckpoint: BlockHeight.ofLatestCheckpoint(network: network),
             endpoint: {
-                // In case of mainnet network we may have stored server as a user action in advanced settings
-                if network.networkType == .mainnet {
-                    @Dependency(\.userDefaults) var userDefaults
-                    
-                    let udKey = ZcashSDKEnvironment.Servers.Constants.udServerKey
-                    
-                    if let storedServerRaw = userDefaults.objectForKey(udKey) as? String,
-                       let storedServer = ZcashSDKEnvironment.Servers(rawValue: storedServerRaw) {
-                        if let endpoint = storedServer.lightWalletEndpoint(userDefaults) {
-                            // Some endpoint is set by a user so we initialize the SDK with this one
-                            return endpoint
-                        } else {
-                            // Initalization of LightWalletEndpoint failed, fallback to hardcoded one,
-                            // setting the mainnet key to the storage to reflect that
-                            userDefaults.setValue(ZcashSDKEnvironment.Servers.globalZR.rawValue, udKey)
-                        }
-                    }
-                }
-                
-                // Hardcoded endpoint
-                return LightWalletEndpoint(
-                    address: Self.endpointString(for: network),
-                    port: network.networkType == .testnet ? ZcashSDKConstants.endpointTestnetPort : ZcashSDKConstants.endpointMainnetPort,
-                    secure: true,
-                    streamingCallTimeoutInMillis: ZcashSDKConstants.streamingCallTimeoutInMillis
-                )
+                ZcashSDKEnvironment.serverConfig(
+                    for: network.networkType
+                ).endpoint(streamingCallTimeoutInMillis: ZcashSDKConstants.streamingCallTimeoutInMillis)
             },
             memoCharLimit: MemoBytes.capacity,
             mnemonicWordsMaxCount: ZcashSDKConstants.mnemonicWordsMaxCount,
             network: network,
             requiredTransactionConfirmations: ZcashSDKConstants.requiredTransactionConfirmations,
             sdkVersion: "0.18.1-beta",
+            serverConfig: { ZcashSDKEnvironment.serverConfig(for: network.networkType) },
+            servers: ZcashSDKEnvironment.servers(for: network.networkType),
             shieldingThreshold: Zatoshi(100_000),
             tokenName: network.networkType == .testnet ? "TAZ" : "ZEC"
         )
+    }
+}
+
+extension ZcashSDKEnvironment {
+    public static func serverConfig(for network: NetworkType) -> UserPreferencesStorage.ServerConfig {
+        migrateVersion1IfNeeded()
+        
+        guard let serverConfig = storedServerConfig() else {
+            return defaultEndpoint(for: network).serverConfig()
+        }
+        
+        return serverConfig
+    }
+    
+    static func migrateVersion1IfNeeded() {
+        @Dependency(\.userStoredPreferences) var userStoredPreferences
+        @Dependency(\.userDefaults) var userDefaults
+
+        let streamingCallTimeoutInMillis = ZcashSDKConstants.streamingCallTimeoutInMillis
+        let udServerKey = "zashi_udServerKey"
+        let udCustomServerKey = "zashi_udCustomServerKey"
+
+        // only if there's no ServerConfig stored
+        guard userStoredPreferences.server() == nil else {
+            userDefaults.remove(udServerKey)
+            userDefaults.remove(udCustomServerKey)
+            return
+        }
+        
+        // get server key
+        guard let storedKey = userDefaults.objectForKey(udServerKey) as? String else {
+            userDefaults.remove(udServerKey)
+            userDefaults.remove(udCustomServerKey)
+            return
+        }
+        
+        // ensure custom server is preserved
+        if storedKey == "custom" {
+            if let customValue = userDefaults.objectForKey(udCustomServerKey) as? String {
+                if let serverConfig = UserPreferencesStorage.ServerConfig.endpoint(
+                    for: customValue,
+                    streamingCallTimeoutInMillis: streamingCallTimeoutInMillis)?.serverConfig(
+                        isCustom: true
+                    ) 
+                {
+                    try? userStoredPreferences.setServer(serverConfig)
+                }
+            }
+        } else if storedKey == "mainnet" {
+            let serverConfig = UserPreferencesStorage.ServerConfig(host: "mainnet.lightwalletd.com", port: 9067, isCustom: true)
+            try? userStoredPreferences.setServer(serverConfig)
+        } else {
+            // some of the lwd servers
+            let serverConfig = UserPreferencesStorage.ServerConfig(host: "\(storedKey.dropLast(2)).lightwalletd.com", port: 443, isCustom: true)
+            try? userStoredPreferences.setServer(serverConfig)
+        }
+    }
+    
+    static func storedServerConfig() -> UserPreferencesStorage.ServerConfig? {
+        @Dependency(\.userStoredPreferences) var userStoredPreferences
+        return userStoredPreferences.server()
     }
 }

--- a/modules/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentTestKey.swift
+++ b/modules/Sources/Dependencies/ZcashSDKEnvironment/ZcashSDKEnvironmentTestKey.swift
@@ -8,25 +8,21 @@
 import ComposableArchitecture
 import ZcashLightClientKit
 import XCTestDynamicOverlay
+import UserPreferencesStorage
 
 extension ZcashSDKEnvironment: TestDependencyKey {
     public static let testnet = ZcashSDKEnvironment.live(network: ZcashNetworkBuilder.network(for: .testnet))
 
     public static let testValue = Self(
         latestCheckpoint: 0,
-        endpoint: {
-            LightWalletEndpoint(
-                address: ZcashSDKConstants.endpointTestnetAddress,
-                port: ZcashSDKConstants.endpointTestnetPort,
-                secure: true,
-                streamingCallTimeoutInMillis: ZcashSDKConstants.streamingCallTimeoutInMillis
-            )
-        },
+        endpoint: { defaultEndpoint(for: .testnet) },
         memoCharLimit: MemoBytes.capacity,
         mnemonicWordsMaxCount: ZcashSDKConstants.mnemonicWordsMaxCount,
         network: ZcashNetworkBuilder.network(for: .testnet),
         requiredTransactionConfirmations: ZcashSDKConstants.requiredTransactionConfirmations,
         sdkVersion: "0.18.1-beta",
+        serverConfig: { defaultEndpoint(for: .testnet).serverConfig() },
+        servers: [],
         shieldingThreshold: Zatoshi(100_000),
         tokenName: "TAZ"
     )

--- a/modules/Sources/Features/Root/RootInitialization.swift
+++ b/modules/Sources/Features/Root/RootInitialization.swift
@@ -463,9 +463,7 @@ extension RootReducer {
                 return .none
                 
             case .initialization(.configureCrashReporter):
-                crashReporter.configure(
-                    !userStoredPreferences.isUserOptedOutOfCrashReporting()
-                )
+                crashReporter.configure(true)
                 return .none
                 
             case .updateStateAfterConfigUpdate(let walletConfig):

--- a/modules/Sources/Features/ServerSetup/ServerSetupView.swift
+++ b/modules/Sources/Features/ServerSetup/ServerSetupView.swift
@@ -17,7 +17,7 @@ public struct ServerSetupView: View {
         // Time it takes to initiate the animated scroll after the screen is presented
         static let delayBeforeScroll = 500_000_000
     }
-    
+
     private enum InputID: Hashable {
         case selection
     }

--- a/modules/Sources/Features/ServerSetup/ServerSetupView.swift
+++ b/modules/Sources/Features/ServerSetup/ServerSetupView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
+import ZcashLightClientKit
 
 import Generated
 import UIComponents
@@ -37,7 +38,7 @@ public struct ServerSetupView: View {
                             .frame(height: 1)
                         
                         ScrollView {
-                            ForEach(ZcashSDKEnvironment.Servers.allCases, id: \.self) { server in
+                            ForEach(store.servers, id: \.self) { server in
                                 WithPerceptionTracking {
                                     VStack {
                                         HStack(spacing: 0) {
@@ -46,7 +47,7 @@ public struct ServerSetupView: View {
                                             } label: {
                                                 HStack(spacing: 10) {
                                                     WithPerceptionTracking {
-                                                        if server == store.server {
+                                                        if server.value(for: store.network) == store.selectedServer {
                                                             Circle()
                                                                 .fill(Asset.Colors.primary.color)
                                                                 .frame(width: 20, height: 20)
@@ -62,9 +63,10 @@ public struct ServerSetupView: View {
                                                         }
                                                     }
                                                     
-                                                    Text(server.server()).tag(server)
+                                                    Text(server.name(for: store.network)).tag(server)
                                                         .font(.custom(FontFamily.Inter.medium.name, size: 14))
                                                         .foregroundColor(Asset.Colors.shade30.color)
+                                                        .multilineTextAlignment(.leading)
                                                 }
                                             }
                                             .padding(.vertical, 6)
@@ -74,7 +76,7 @@ public struct ServerSetupView: View {
                                         .frame(maxWidth: .infinity)
                                         
                                         WithPerceptionTracking {
-                                            if store.server == .custom && server == .custom {
+                                            if store.selectedServer == L10n.ServerSetup.custom && server.value(for: store.network) == L10n.ServerSetup.custom {
                                                 TextField(L10n.ServerSetup.placeholder, text: $store.customServer)
                                                     .frame(height: 40)
                                                     .font(.custom(FontFamily.Inter.medium.name, size: 14))
@@ -91,7 +93,7 @@ public struct ServerSetupView: View {
                                         }
                                     }
                                     .padding(.horizontal, 35)
-                                    .id(server == store.server ? InputID.selection : nil)
+                                    .id(server.value(for: store.network) == store.selectedServer ? InputID.selection : nil)
                                 }
                             }
                             .padding(.vertical, 20)

--- a/modules/Sources/Generated/L10n.swift
+++ b/modules/Sources/Generated/L10n.swift
@@ -468,6 +468,12 @@ public enum L10n {
     }
   }
   public enum ServerSetup {
+    /// custom
+    public static let custom = L10n.tr("Localizable", "serverSetup.custom", fallback: "custom")
+    /// default: currently %@
+    public static func `default`(_ p1: Any) -> String {
+      return L10n.tr("Localizable", "serverSetup.default", String(describing: p1), fallback: "default: currently %@")
+    }
     /// <hostname>:<port>
     public static let placeholder = L10n.tr("Localizable", "serverSetup.placeholder", fallback: "<hostname>:<port>")
     /// Server

--- a/modules/Sources/Generated/Resources/Localizable.strings
+++ b/modules/Sources/Generated/Resources/Localizable.strings
@@ -66,6 +66,8 @@
 
 // MARK: - Address Details
 "serverSetup.title" = "Server";
+"serverSetup.custom" = "custom";
+"serverSetup.default" = "default: currently %@";
 "serverSetup.placeholder" = "<hostname>:<port>";
 "serverSetup.alert.failed.title" = "Invalid endpoint";
 "serverSetup.alert.failed.message" = "Error: %@";

--- a/secantTests/UtilTests/UserPreferencesStorageTests.swift
+++ b/secantTests/UtilTests/UserPreferencesStorageTests.swift
@@ -23,12 +23,7 @@ class UserPreferencesStorageTests: XCTestCase {
         }
         
         storage = UserPreferencesStorage(
-            appSessionFrom: 12345678.0,
-            convertedCurrency: "USD",
-            fiatConvertion: true,
-            recoveryPhraseTestCompleted: true,
-            sessionAutoshielded: false,
-            userOptedOutOfCrashReporting: true,
+            defaultServer: Data(),
             userDefaults: .live(userDefaults: userDefaults)
         )
         storage.removeAll()
@@ -42,158 +37,34 @@ class UserPreferencesStorageTests: XCTestCase {
     
     // MARK: - Default values in the live UserDefaults environment
     
-    func testAppSessionFrom_defaultValue() throws {
-        XCTAssertEqual(12345678.0, storage.activeAppSessionFrom, "User Preferences: `activeAppSessionFrom` default doesn't match.")
-    }
-
-    func testConvertedCurrency_defaultValue() throws {
-        XCTAssertEqual("USD", storage.currency, "User Preferences: `currency` default doesn't match.")
-    }
-
-    func testFiatConvertion_defaultValue() throws {
-        XCTAssertEqual(true, storage.isFiatConverted, "User Preferences: `isFiatConverted` default doesn't match.")
-    }
-
-    func testRecoveryPhraseTestCompleted_defaultValue() throws {
-        XCTAssertEqual(true, storage.isRecoveryPhraseTestCompleted, "User Preferences: `isRecoveryPhraseTestCompleted` default doesn't match.")
-    }
-
-    func testSessionAutoshielded_defaultValue() throws {
-        XCTAssertEqual(false, storage.isSessionAutoshielded, "User Preferences: `isSessionAutoshielded` default doesn't match.")
+    func testDefaultServer_defaultValue() throws {
+        XCTAssertEqual(nil, storage.server, "User Preferences: `defaultServer` default doesn't match.")
     }
 
     // MARK: - Set new values in the live UserDefaults environment
 
-    func testAppSessionFrom_setNewValue() async throws {
-        await storage.setActiveAppSessionFrom(87654321.0)
+    func testDefaultServer_setNewValue() throws {
+        let serverConfig = UserPreferencesStorage.ServerConfig(host: "host", port: 13, isCustom: true)
+        try storage.setServer(serverConfig)
 
-        XCTAssertEqual(87654321.0, storage.activeAppSessionFrom, "User Preferences: `activeAppSessionFrom` default doesn't match.")
-    }
-
-    func testConvertedCurrency_setNewValue() async throws {
-        await storage.setCurrency("CZK")
-
-        XCTAssertEqual("CZK", storage.currency, "User Preferences: `currency` default doesn't match.")
-    }
-
-    func testFiatConvertion_setNewValue() async throws {
-        await storage.setIsFiatConverted(false)
-
-        XCTAssertEqual(false, storage.isFiatConverted, "User Preferences: `isFiatConverted` default doesn't match.")
-    }
-
-    func testRecoveryPhraseTestCompleted_setNewValue() async throws {
-        await storage.setIsRecoveryPhraseTestCompleted(false)
-
-        XCTAssertEqual(false, storage.isRecoveryPhraseTestCompleted, "User Preferences: `isRecoveryPhraseTestCompleted` default doesn't match.")
-    }
-
-    func testSessionAutoshielded_setNewValue() async throws {
-        await storage.setIsSessionAutoshielded(true)
-
-        XCTAssertEqual(true, storage.isSessionAutoshielded, "User Preferences: `isSessionAutoshielded` default doesn't match.")
+        XCTAssertEqual(serverConfig, storage.server, "User Preferences: `server` default doesn't match.")
     }
 
     // MARK: - Mocked user defaults vs. default values
 
-    func testAppSessionFrom_mocked() throws {
+    func testDefaultServer_mocked() throws {
         let mockedUD = UserDefaultsClient(
-            objectForKey: { _ in 87654321.0 },
+            objectForKey: { _ in Data() },
             remove: { _ in },
             setValue: { _, _ in }
         )
         
         let mockedStorage = UserPreferencesStorage(
-            appSessionFrom: 12345678.0,
-            convertedCurrency: "USD",
-            fiatConvertion: true,
-            recoveryPhraseTestCompleted: true,
-            sessionAutoshielded: false,
-            userOptedOutOfCrashReporting: true,
+            defaultServer: Data(),
             userDefaults: mockedUD
         )
 
-        XCTAssertEqual(87654321.0, mockedStorage.activeAppSessionFrom, "User Preferences: `activeAppSessionFrom` default doesn't match.")
-    }
-
-    func testConvertedCurrency_mocked() throws {
-        let mockedUD = UserDefaultsClient(
-            objectForKey: { _ in "CZK" },
-            remove: { _ in },
-            setValue: { _, _ in }
-        )
-        
-        let mockedStorage = UserPreferencesStorage(
-            appSessionFrom: 12345678.0,
-            convertedCurrency: "USD",
-            fiatConvertion: true,
-            recoveryPhraseTestCompleted: true,
-            sessionAutoshielded: false,
-            userOptedOutOfCrashReporting: true,
-            userDefaults: mockedUD
-        )
-
-        XCTAssertEqual("CZK", mockedStorage.currency, "User Preferences: `currency` default doesn't match.")
-    }
-
-    func testFiatConvertion_mocked() throws {
-        let mockedUD = UserDefaultsClient(
-            objectForKey: { _ in false },
-            remove: { _ in },
-            setValue: { _, _ in }
-        )
-        
-        let mockedStorage = UserPreferencesStorage(
-            appSessionFrom: 12345678.0,
-            convertedCurrency: "USD",
-            fiatConvertion: true,
-            recoveryPhraseTestCompleted: true,
-            sessionAutoshielded: false,
-            userOptedOutOfCrashReporting: true,
-            userDefaults: mockedUD
-        )
-
-        XCTAssertEqual(false, mockedStorage.isFiatConverted, "User Preferences: `isFiatConverted` default doesn't match.")
-    }
-
-    func testRecoveryPhraseTestCompleted_mocked() throws {
-        let mockedUD = UserDefaultsClient(
-            objectForKey: { _ in false },
-            remove: { _ in },
-            setValue: { _, _ in }
-        )
-        
-        let mockedStorage = UserPreferencesStorage(
-            appSessionFrom: 12345678.0,
-            convertedCurrency: "USD",
-            fiatConvertion: true,
-            recoveryPhraseTestCompleted: true,
-            sessionAutoshielded: false,
-            userOptedOutOfCrashReporting: true,
-            userDefaults: mockedUD
-        )
-
-        XCTAssertEqual(false, mockedStorage.isRecoveryPhraseTestCompleted, "User Preferences: `isRecoveryPhraseTestCompleted` default doesn't match.")
-    }
-
-    func testSessionAutoshielded_mocked() throws {
-        let mockedUD = UserDefaultsClient(
-            objectForKey: { _ in true },
-            remove: { _ in },
-            setValue: { _, _ in }
-        )
-        
-        let mockedStorage = UserPreferencesStorage(
-            appSessionFrom: 12345678.0,
-            convertedCurrency: "USD",
-            fiatConvertion: true,
-            recoveryPhraseTestCompleted: true,
-            sessionAutoshielded: false,
-            userOptedOutOfCrashReporting: true,
-            userDefaults: mockedUD
-        )
-
-        XCTAssertEqual(true, mockedStorage.isSessionAutoshielded, "User Preferences: `isSessionAutoshielded` default doesn't match.")
+        XCTAssertEqual(nil, mockedStorage.server, "User Preferences: `server` default doesn't match.")
     }
 
     // MARK: - Remove all keys from the live UD environment


### PR DESCRIPTION
Closes #1223 

- The version1 has been completely refactored and redesigned
- Servers are newly represented as enums allowing customization of naming and localization (the custom and default servers)
- The list of servers is now network dependent, different for testnet vs. mainnet
- The selected server is now represented as Hashable and Codable struct ServerConfig that holds the host, port and isCustom flag
- Migration of version1 implemented that ensures to persist previous choice of a user and fills it in a custom field
- The UI dynamically ensures the host & port are at one line, not split to multiline label
- The persistency of a choice is now handled by UserPreferencesStorage, a dependency designed for user settings instead of a direct access to the UserDefaults
- Tests fixed

![simulator_screenshot_D84E12FA-693E-4841-83E5-9981F0BF4B60](https://github.com/Electric-Coin-Company/zashi-ios/assets/7198042/d9d3bce2-3a44-4a2d-af29-e246b5ff56a9)

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [x] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [ ] Does the code abide by the [Coding Guidelines](../blob/main/docs/CODING_GUIDELINES.md)?
- [ ] Automated tests: Did you add appropriate automated tests for any code changes?
- [x] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [x] Run the app: Did you run the app and try the changes? 
- [x] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [ ] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/main/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage before and after your changes and when possible, leave it in a better place. [Learn More...](../blob/main/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/main/README.md), [LICENSE.md](../blob/main/LICENSE.md), and [Architecture.md](../blob/main/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.